### PR TITLE
Nick O Fixes #3

### DIFF
--- a/app/views/days/new.html.erb
+++ b/app/views/days/new.html.erb
@@ -126,7 +126,7 @@
         var dateObj = new Date( $("#month").val() + " 1," + $("#year").val())
         
         // format the date and send the callendar to that date
-        var formattedDate = dateObj.getFullYear() + "-" + (dateObj.getMonth() + 1) + "-" + dateObj.getDate();
+        var formattedDate = dateObj.getFullYear() + "-" + ("0" + (dateObj.getMonth() + 1)).slice(-2) + "-" + ("0" + dateObj.getDate()).slice(-2);
         $("#calendar").fullCalendar( 'gotoDate', formattedDate)
         
         var numDaysInMonth = new Date(dateObj.getFullYear(), dateObj.getMonth() + 1, 0).getDate()


### PR DESCRIPTION
fixed #71. Added some funky formatting to fix the calendar breaking when selecting a date form the frop downs. For some reason Firefox/Safari didn't like the dates without leading zeros on single digit days/months. i.e.: 2016-5-1 throws an error while 2016-05-01 does not.